### PR TITLE
feat(order): implement order updation for admin users

### DIFF
--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -37,4 +37,6 @@ router.get('/', orderController.getAllOrders);
 
 router.post('/admin', orderController.createAdminOrder);
 
+router.patch('/:id/status', orderController.updateOrderStatus);
+
 module.exports = router;


### PR DESCRIPTION
This PR introduces update order functionality by admin users.

- Add PATCH /api/orders/:id/status endpoint
- Implement status transition validation
- Enforce business rules (e.g., no delivered → pending)
- Make operation idempotent
- Admin-only access via restrictTo middleware

Valid transitions:
  pending → confirmed, cancelled
  confirmed → shipped, cancelled
  shipped → delivered
  delivered, cancelled → (final states)

Why: Provides admin control over order lifecycle
Trade-off: Strict transitions vs flexibility (chose strict for data integrity)

Fixes #26 